### PR TITLE
F12

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,34 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link href="https://fonts.googleapis.com/css2?family=Amatic+SC:wght@400;700&family=Open+Sans:wght@500&display=swap"
-    rel="stylesheet">
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
+    <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta name="theme-color" content="#000000" />
       
-    -->
-    <title>Crazee Burger</title>
-  </head>
+      <meta name="robots" content="index, follow" />
+      <meta name="description" content="Commandez de délicieux burgers artisanaux faits maison chez Crazee Burger. Livraison rapide, produits frais, goût exceptionnel." />
+      <meta name="keywords" content="burger, livraison burger, burger maison, fast food, Crazee Burger" />
+      
+      <meta property="og:title" content="Crazee Burger - Livraison de burgers artisanaux" />
+      <meta property="og:description" content="Commandez vos burgers préférés en ligne. Livraison rapide et produits frais !" />
+      <meta property="og:image" content="/logo192.png" />
+      <meta property="og:url" content="https://crazee-burger.vercel.app" />
+      <meta property="og:type" content="website" />
+      
+      <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+      <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+      <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+      <link href="https://fonts.googleapis.com/css2?family=Amatic+SC:wght@400;700&family=Open+Sans:wght@500&display=swap" rel="stylesheet" />
+      <title>Crazee Burger - Livraison de burgers artisanaux</title>
+    </head>    
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>

--- a/src/components/pages/order/OrderPage.js
+++ b/src/components/pages/order/OrderPage.js
@@ -7,7 +7,7 @@ import OrderContext from '../../../context/OrderContext';
 import { EMPTY_PRODUCT } from '../../../enums/product';
 import { useMenu } from '../../../hooks/useMenu';
 import { useBasket } from '../../../hooks/useBasket';
-import { find } from '../../../utils/array';
+import { findObjectById } from '../../../utils/array';
 
 const OrderPage = () => {
   //state
@@ -23,9 +23,9 @@ const OrderPage = () => {
   const { basket, handleAddToBasket, handleDeleteBasketProduct } = useBasket()
 
   const handleProductSelected = async (idProductClicked) => {
+    const productClickedOn = findObjectById(idProductClicked, menu)
     await setIsCollapsed(false)
     await setCurrentTabSelected("edit")
-    const productClickedOn = find(idProductClicked, menu)
     await setProductSelected(productClickedOn)
     titleEditRef.current.focus()
   }

--- a/src/components/pages/order/admin/AdminPanel/AddForm.js
+++ b/src/components/pages/order/admin/AdminPanel/AddForm.js
@@ -4,6 +4,7 @@ import { EMPTY_PRODUCT } from '../../../../../enums/product';
 import Form from './Form';
 import { useSuccessMessage } from '../../../../../hooks/useSuccessMessage';
 import SubmitButton from './SubmitButton';
+import { replaceFrenchCommaWithDot } from '../../../../../utils/maths';
 
 export default function AddForm() {
   //state
@@ -16,7 +17,8 @@ export default function AddForm() {
     e.preventDefault()
     const newProductToAdd = {
       ...newProduct,
-      id: crypto.randomUUID()
+      id: crypto.randomUUID(),
+      price: replaceFrenchCommaWithDot(newProduct.price),
       //id: new Date().getTime()
     }
     handleAdd(newProductToAdd)

--- a/src/components/pages/order/main/Basket/Basket.js
+++ b/src/components/pages/order/main/Basket/Basket.js
@@ -3,7 +3,6 @@ import Total from "./Total"
 import Footer from "./Footer"
 import { useContext } from "react"
 import OrderContext from "../../../../../context/OrderContext"
-import { formatPrice } from "../../../../../utils/maths"
 import BasketProducts from "./BasketProducts"
 import { theme } from "../../../../../theme"
 import EmptyBasket from "./EmptyBasket"
@@ -11,27 +10,13 @@ import { isEmpty } from "../../../../../utils/array"
 
 
 export default function Basket() {
-  const { basket, isModeAdmin, handleDeleteBasketProduct } = useContext(OrderContext)
+  const { basket } = useContext(OrderContext)
 
-  const isBasketEmpty = isEmpty(basket)
-
-  const sumToPay = basket.reduce((total, basketProduct) => {
-    total += basketProduct.price * basketProduct.quantity
-    return total
-  }, 0)
 
   return (
     <BasketStyled>
-      <Total amountToPay={formatPrice(sumToPay)} />
-      {isBasketEmpty ? (
-        <EmptyBasket />
-      ) : (
-        <BasketProducts
-          basket={basket}
-          isModeAdmin={isModeAdmin}
-          handleDeleteBasketProduct={handleDeleteBasketProduct}
-        />
-      )}
+      <Total />
+      {isEmpty(basket) ? <EmptyBasket /> : <BasketProducts />}
       <Footer />
     </BasketStyled>
   )

--- a/src/components/pages/order/main/Basket/Basket.js
+++ b/src/components/pages/order/main/Basket/Basket.js
@@ -7,12 +7,13 @@ import { formatPrice } from "../../../../../utils/maths"
 import BasketProducts from "./BasketProducts"
 import { theme } from "../../../../../theme"
 import EmptyBasket from "./EmptyBasket"
+import { isEmpty } from "../../../../../utils/array"
 
 
 export default function Basket() {
-  const { basket } = useContext(OrderContext)
+  const { basket, isModeAdmin, handleDeleteBasketProduct } = useContext(OrderContext)
 
-  const isBasketEmpty = basket.length === 0
+  const isBasketEmpty = isEmpty(basket)
 
   const sumToPay = basket.reduce((total, basketProduct) => {
     total += basketProduct.price * basketProduct.quantity
@@ -22,7 +23,15 @@ export default function Basket() {
   return (
     <BasketStyled>
       <Total amountToPay={formatPrice(sumToPay)} />
-      {isBasketEmpty ? <EmptyBasket /> : <BasketProducts />}
+      {isBasketEmpty ? (
+        <EmptyBasket />
+      ) : (
+        <BasketProducts
+          basket={basket}
+          isModeAdmin={isModeAdmin}
+          handleDeleteBasketProduct={handleDeleteBasketProduct}
+        />
+      )}
       <Footer />
     </BasketStyled>
   )

--- a/src/components/pages/order/main/Basket/BasketCard.js
+++ b/src/components/pages/order/main/Basket/BasketCard.js
@@ -13,9 +13,10 @@ export default function BasketCard({
   isClickable,
   onClick,
   onDelete,
+  isSelected,
 }) {
   return (
-    <BasketCardStyled className={className} $isClickable={isClickable} onClick={onClick}>
+    <BasketCardStyled className={className} $isClickable={isClickable} onClick={onClick} $isSelected={isSelected}>
       <div className="delete-button" onClick={onDelete}>
         <MdDeleteForever className="icon" />
       </div>

--- a/src/components/pages/order/main/Basket/BasketCard.js
+++ b/src/components/pages/order/main/Basket/BasketCard.js
@@ -10,18 +10,11 @@ export default function BasketCard({
   quantity,
   imageSource,
   className,
-  isClickable,
-  isSelected,
+  isModeAdmin,
   onDelete,
-  onClick,
 }) {
   return (
-    <BasketCardStyled
-      className={className}
-      $isClickable={isClickable}
-      onClick={onClick}
-      $isSelected={isSelected}
-    >
+    <BasketCardStyled className={className} $isModeAdmin={isModeAdmin}>
       <div className="delete-button" onClick={onDelete}>
         <MdDeleteForever className="icon" />
       </div>
@@ -44,7 +37,7 @@ export default function BasketCard({
 }
 
 const BasketCardStyled = styled.div`
-  cursor: ${({ $isClickable }) => ($isClickable ? "pointer" : "auto")};
+  cursor: ${({ $isModeAdmin }) => ($isModeAdmin ? "pointer" : "auto")};
   /* border: 1px solid red; */
   box-sizing: border-box;
   height: 86px;

--- a/src/components/pages/order/main/Basket/BasketCard.js
+++ b/src/components/pages/order/main/Basket/BasketCard.js
@@ -10,11 +10,11 @@ export default function BasketCard({
   quantity,
   imageSource,
   className,
-  isModeAdmin,
+  isClickable,
   onDelete,
 }) {
   return (
-    <BasketCardStyled className={className} $isModeAdmin={isModeAdmin}>
+    <BasketCardStyled className={className} $isClickable={isClickable}>
       <div className="delete-button" onClick={onDelete}>
         <MdDeleteForever className="icon" />
       </div>
@@ -37,7 +37,7 @@ export default function BasketCard({
 }
 
 const BasketCardStyled = styled.div`
-  cursor: ${({ $isModeAdmin }) => ($isModeAdmin ? "pointer" : "auto")};
+  cursor: ${({ $isClickable }) => ($isClickable ? "pointer" : "auto")};
   /* border: 1px solid red; */
   box-sizing: border-box;
   height: 86px;

--- a/src/components/pages/order/main/Basket/BasketCard.js
+++ b/src/components/pages/order/main/Basket/BasketCard.js
@@ -11,10 +11,11 @@ export default function BasketCard({
   imageSource,
   className,
   isClickable,
+  onClick,
   onDelete,
 }) {
   return (
-    <BasketCardStyled className={className} $isClickable={isClickable}>
+    <BasketCardStyled className={className} $isClickable={isClickable} onClick={onClick}>
       <div className="delete-button" onClick={onDelete}>
         <MdDeleteForever className="icon" />
       </div>

--- a/src/components/pages/order/main/Basket/BasketProducts.js
+++ b/src/components/pages/order/main/Basket/BasketProducts.js
@@ -1,15 +1,17 @@
 import React from "react"
 import { useContext } from "react"
 import styled from "styled-components"
-import OrderContext from "../../../../../context/OrderContext"
-import { findObjectById } from "../../../../../utils/array"
 import BasketCard from "./BasketCard"
+import { findObjectById } from "../../../../../utils/array"
 import { IMAGE_COMING_SOON } from "../../../../../enums/product"
+import OrderContext from "../../../../../context/OrderContext"
 
 export default function BasketProducts() {
-  const { basket, isModeAdmin, handleDeleteBasketProduct, menu } = useContext(OrderContext)
+  const { basket, isModeAdmin, handleDeleteBasketProduct, menu, handleProductSelected } =
+    useContext(OrderContext)
 
-  const handleOnDelete = (id) => {
+  const handleOnDelete = (event, id) => {
+    event.stopPropagation()
     handleDeleteBasketProduct(id)
   }
 
@@ -23,8 +25,9 @@ export default function BasketProducts() {
               {...menuProduct}
               imageSource={menuProduct.imageSource ? menuProduct.imageSource : IMAGE_COMING_SOON}
               quantity={basketProduct.quantity}
-              onDelete={() => handleOnDelete(basketProduct.id)}
+              onDelete={(event) => handleOnDelete(event, basketProduct.id)}
               isClickable={isModeAdmin}
+              onClick={isModeAdmin ? () => handleProductSelected(basketProduct.id) : null}
             />
           </div>
         )

--- a/src/components/pages/order/main/Basket/BasketProducts.js
+++ b/src/components/pages/order/main/Basket/BasketProducts.js
@@ -5,9 +5,10 @@ import BasketCard from "./BasketCard"
 import { findObjectById } from "../../../../../utils/array"
 import { IMAGE_COMING_SOON } from "../../../../../enums/product"
 import OrderContext from "../../../../../context/OrderContext"
+import { checkIfProductIsClicked } from "../MainRightSide/Menu/helper"
 
 export default function BasketProducts() {
-  const { basket, isModeAdmin, handleDeleteBasketProduct, menu, handleProductSelected } =
+  const { basket, isModeAdmin, handleDeleteBasketProduct, menu, handleProductSelected , productSelected,} =
     useContext(OrderContext)
 
   const handleOnDelete = (event, id) => {
@@ -28,6 +29,7 @@ export default function BasketProducts() {
               onDelete={(event) => handleOnDelete(event, basketProduct.id)}
               isClickable={isModeAdmin}
               onClick={isModeAdmin ? () => handleProductSelected(basketProduct.id) : null}
+              isSelected={checkIfProductIsClicked(basketProduct.id, productSelected.id)}
             />
           </div>
         )

--- a/src/components/pages/order/main/Basket/BasketProducts.js
+++ b/src/components/pages/order/main/Basket/BasketProducts.js
@@ -1,22 +1,12 @@
-import React, { useContext } from "react"
+import React from "react"
 import styled from "styled-components"
-import OrderContext from "../../../../../context/OrderContext"
-import { IMAGE_COMING_SOON } from "../../../../../enums/product"
 import BasketCard from "./BasketCard"
-import { checkIfProductIsClicked } from "../MainRightSide/Menu/helper"
+import { IMAGE_COMING_SOON } from "../../../../../enums/product"
 
-export default function BasketProducts() {
-  const { basket, isModeAdmin, handleDeleteBasketProduct, handleProductSelected, productSelected } =
-    useContext(OrderContext)
 
-  const handleOnDelete = (event, id) => {
-    event.stopPropagation()
+export default function BasketProducts({ basket, isModeAdmin, handleDeleteBasketProduct }) {
+  const handleOnDelete = (id) => {
     handleDeleteBasketProduct(id)
-  }
-
-  const handleCardClick = (id) => {
-    if (!isModeAdmin) return
-    handleProductSelected(id)
   }
 
   return (
@@ -26,10 +16,8 @@ export default function BasketProducts() {
           <BasketCard
             {...basketProduct}
             imageSource={basketProduct.imageSource ? basketProduct.imageSource : IMAGE_COMING_SOON}
-            onDelete={(event) => handleOnDelete(event, basketProduct.id)}
+            onDelete={() => handleOnDelete(basketProduct.id)}
             isClickable={isModeAdmin}
-            onClick={() => handleCardClick(basketProduct.id)}
-            isSelected={checkIfProductIsClicked(basketProduct.id, productSelected.id)}
           />
         </div>
       ))}

--- a/src/components/pages/order/main/Basket/BasketProducts.js
+++ b/src/components/pages/order/main/Basket/BasketProducts.js
@@ -1,26 +1,34 @@
 import React from "react"
+import { useContext } from "react"
 import styled from "styled-components"
+import OrderContext from "../../../../../context/OrderContext"
+import { findObjectById } from "../../../../../utils/array"
 import BasketCard from "./BasketCard"
 import { IMAGE_COMING_SOON } from "../../../../../enums/product"
 
+export default function BasketProducts() {
+  const { basket, isModeAdmin, handleDeleteBasketProduct, menu } = useContext(OrderContext)
 
-export default function BasketProducts({ basket, isModeAdmin, handleDeleteBasketProduct }) {
   const handleOnDelete = (id) => {
     handleDeleteBasketProduct(id)
   }
 
   return (
     <BasketProductsStyled>
-      {basket.map((basketProduct) => (
-        <div className="basket-card" key={basketProduct.id}>
-          <BasketCard
-            {...basketProduct}
-            imageSource={basketProduct.imageSource ? basketProduct.imageSource : IMAGE_COMING_SOON}
-            onDelete={() => handleOnDelete(basketProduct.id)}
-            isClickable={isModeAdmin}
-          />
-        </div>
-      ))}
+      {basket.map((basketProduct) => {
+        const menuProduct = findObjectById(basketProduct.id, menu)
+        return (
+          <div className="basket-card" key={basketProduct.id}>
+            <BasketCard
+              {...menuProduct}
+              imageSource={menuProduct.imageSource ? menuProduct.imageSource : IMAGE_COMING_SOON}
+              quantity={basketProduct.quantity}
+              onDelete={() => handleOnDelete(basketProduct.id)}
+              isClickable={isModeAdmin}
+            />
+          </div>
+        )
+      })}
     </BasketProductsStyled>
   )
 }

--- a/src/components/pages/order/main/Basket/Total.js
+++ b/src/components/pages/order/main/Basket/Total.js
@@ -1,14 +1,15 @@
 import styled from "styled-components"
 import Header from "../../../../reusable-ui/Header"
 import { theme } from "../../../../../theme"
-import { calculateSumToPay, formatPrice } from "../../../../../utils/maths"
+import { formatPrice } from "../../../../../utils/maths"
 import { useContext } from "react"
 import OrderContext from "../../../../../context/OrderContext"
+import { calculateSumToPay } from "./helper"
 
 export default function Total() {
   const { basket, menu } = useContext(OrderContext)
   const sumToPay = calculateSumToPay(basket, menu)
-  
+
   return (
     <Header>
       <TotalStyled>

--- a/src/components/pages/order/main/Basket/Total.js
+++ b/src/components/pages/order/main/Basket/Total.js
@@ -1,13 +1,19 @@
 import styled from "styled-components"
 import Header from "../../../../reusable-ui/Header"
 import { theme } from "../../../../../theme"
+import { calculateSumToPay, formatPrice } from "../../../../../utils/maths"
+import { useContext } from "react"
+import OrderContext from "../../../../../context/OrderContext"
 
-export default function Total({ amountToPay }) {
+export default function Total() {
+  const { basket, menu } = useContext(OrderContext)
+  const sumToPay = calculateSumToPay(basket, menu)
+  
   return (
     <Header>
       <TotalStyled>
         <span className="total">Total</span>
-        <span className="amount">{amountToPay}</span>
+        <span className="amount">{formatPrice(sumToPay)}</span>
       </TotalStyled>
     </Header>
   )

--- a/src/components/pages/order/main/Basket/helper.js
+++ b/src/components/pages/order/main/Basket/helper.js
@@ -3,6 +3,7 @@ import { findObjectById } from "../../../../../utils/array"
 export const calculateSumToPay = (basket, menu) => {
   return basket.reduce((total, basketProduct) => {
     const menuProduct = findObjectById(basketProduct.id, menu)
+    if (isNaN(menuProduct.price)) return total
     total += menuProduct.price * basketProduct.quantity
     return total
   }, 0)

--- a/src/components/pages/order/main/Basket/helper.js
+++ b/src/components/pages/order/main/Basket/helper.js
@@ -1,0 +1,9 @@
+import { findObjectById } from "../../../../../utils/array"
+
+export const calculateSumToPay = (basket, menu) => {
+  return basket.reduce((total, basketProduct) => {
+    const menuProduct = findObjectById(basketProduct.id, menu)
+    total += menuProduct.price * basketProduct.quantity
+    return total
+  }, 0)
+}

--- a/src/components/pages/order/main/MainRightSide/Menu/Menu.js
+++ b/src/components/pages/order/main/MainRightSide/Menu/Menu.js
@@ -57,8 +57,7 @@ export default function Menu() {
 
   const handleAddButton = (event, idProductToAdd) => {
     event.stopPropagation()
-    const productToAdd = findObjectById(idProductToAdd, menu)
-    handleAddToBasket(productToAdd)
+    handleAddToBasket(idProductToAdd)
   }
 
   return (

--- a/src/components/pages/order/main/MainRightSide/Menu/Menu.js
+++ b/src/components/pages/order/main/MainRightSide/Menu/Menu.js
@@ -8,7 +8,7 @@ import EmptyMenuClient from './EmptyMenuClient'
 import EmptyMenuAdmin from './EmptyMenuAdmin'
 import { checkIfProductIsClicked } from './helper'
 import { EMPTY_PRODUCT, IMAGE_COMING_SOON } from '../../../../../../enums/product'
-import { findObjectById, isEmpty } from '../../../../../../utils/array'
+import { isEmpty } from '../../../../../../utils/array'
 
 export default function Menu() {
   const {
@@ -18,30 +18,14 @@ export default function Menu() {
     resetMenu, 
     productSelected, 
     setProductSelected,
-    setIsCollapsed,
-    setCurrentTabSelected, 
-    titleEditRef,
     handleAddToBasket,
     handleDeleteBasketProduct,
+    handleProductSelected,
   } = useContext(OrderContext)
   //state
   
 
   //comportements (gestionnaire de state ou "state handlers")
-  const handleClick = async (idProductClicked) => {
-    if(!isModeAdmin) return
-    await setIsCollapsed(false)
-    await setCurrentTabSelected("edit")
-    const productClickedOn = findObjectById(idProductClicked, menu)
-    await setProductSelected(productClickedOn)
-    titleEditRef.current.focus()
-  }
-    
-  //affichage
-  if (isEmpty(menu)) {
-    if (!isModeAdmin) return <EmptyMenuClient />
-    return <EmptyMenuAdmin onReset={resetMenu} />
-  }
 
   const handleCardDelete = (event, idProductToDelete) => {
     event.stopPropagation()
@@ -50,14 +34,17 @@ export default function Menu() {
     if (idProductToDelete === productSelected.id) {
       setProductSelected(EMPTY_PRODUCT);
     }
-    if (titleEditRef?.current) {
-      titleEditRef.current.focus();
-    }
   }
 
   const handleAddButton = (event, idProductToAdd) => {
     event.stopPropagation()
     handleAddToBasket(idProductToAdd)
+  }
+
+   // affichage
+   if (isEmpty(menu)) {
+    if (!isModeAdmin) return <EmptyMenuClient />
+    return <EmptyMenuAdmin onReset={resetMenu} />
   }
 
   return (
@@ -71,7 +58,7 @@ export default function Menu() {
               leftDescription={formatPrice(price)}
               hasDeleteButton={isModeAdmin}
               onDelete={(event) => handleCardDelete(event, id)}
-              onClick={() => handleClick(id) }
+              onClick={isModeAdmin ? () => handleProductSelected(id) : null}
               isHoverable={isModeAdmin}
               isSelected={checkIfProductIsClicked(id, productSelected.id)}
               onAdd={(event) => handleAddButton(event, id)}

--- a/src/components/pages/order/main/MainRightSide/Menu/Menu.js
+++ b/src/components/pages/order/main/MainRightSide/Menu/Menu.js
@@ -8,7 +8,7 @@ import EmptyMenuClient from './EmptyMenuClient'
 import EmptyMenuAdmin from './EmptyMenuAdmin'
 import { checkIfProductIsClicked } from './helper'
 import { EMPTY_PRODUCT, IMAGE_COMING_SOON } from '../../../../../../enums/product'
-import { find } from '../../../../../../utils/array'
+import { findObjectById, isEmpty } from '../../../../../../utils/array'
 
 export default function Menu() {
   const {
@@ -17,10 +17,12 @@ export default function Menu() {
     handleDelete, 
     resetMenu, 
     productSelected, 
-    setProductSelected, 
-    handleProductSelected,
+    setProductSelected,
+    setIsCollapsed,
+    setCurrentTabSelected, 
     titleEditRef,
     handleAddToBasket,
+    handleDeleteBasketProduct,
   } = useContext(OrderContext)
   //state
   
@@ -28,11 +30,15 @@ export default function Menu() {
   //comportements (gestionnaire de state ou "state handlers")
   const handleClick = async (idProductClicked) => {
     if(!isModeAdmin) return
-    handleProductSelected(idProductClicked)
+    await setIsCollapsed(false)
+    await setCurrentTabSelected("edit")
+    const productClickedOn = findObjectById(idProductClicked, menu)
+    await setProductSelected(productClickedOn)
+    titleEditRef.current.focus()
   }
     
   //affichage
-  if (menu.length === 0) {
+  if (isEmpty(menu)) {
     if (!isModeAdmin) return <EmptyMenuClient />
     return <EmptyMenuAdmin onReset={resetMenu} />
   }
@@ -40,6 +46,7 @@ export default function Menu() {
   const handleCardDelete = (event, idProductToDelete) => {
     event.stopPropagation()
     handleDelete(idProductToDelete)
+    handleDeleteBasketProduct(idProductToDelete)
     if (idProductToDelete === productSelected.id) {
       setProductSelected(EMPTY_PRODUCT);
     }
@@ -50,8 +57,7 @@ export default function Menu() {
 
   const handleAddButton = (event, idProductToAdd) => {
     event.stopPropagation()
-    //const productToAdd = menu.find((menuProduct) => menuProduct.id === idProductToAdd)
-    const productToAdd = find(idProductToAdd, menu)
+    const productToAdd = findObjectById(idProductToAdd, menu)
     handleAddToBasket(productToAdd)
   }
 

--- a/src/context/OrderContext.js
+++ b/src/context/OrderContext.js
@@ -3,16 +3,21 @@ import { createContext } from "react";
 export default createContext ({
     isModeAdmin: false,
     setIsModeAdmin: () => {},
+
     isTabSelected: "",
     setIsTabSelected: () => {},
+
     isCollapsed: false,
     setIsCollapsed: () => {},
+
     isAddSelected: true,
     setIsAddSelected: () => {},
     isEditSelected: false,
     setIsEditSelected: () => {},
+
     currentTabSelected: false,
     setCurrentTabSelected: () => {},
+
     menu: [],
     setMenu : () => {},
     handleAdd : () => {},
@@ -22,10 +27,10 @@ export default createContext ({
 
     newProduct: {},
     setNewProduct: () => {},
-    handleProductSelected: () => {},
 
     productSelected: {},
     setProductSelected: () => {},
+    handleProductSelected: () => {},
 
     titleEditRef: {},
 

--- a/src/hooks/useBasket.js
+++ b/src/hooks/useBasket.js
@@ -31,14 +31,7 @@ export const useBasket = () => {
   }
 
   const handleDeleteBasketProduct = (idBasketProduct) => {
-    //1. copy du state (optional because filter returns a new array )
-    const basketCopy = deepClone(basket)
-
-    //2. manip de la copie state
-    //const basketUpdated = basketCopy.filter((product) => product.id !== idBasketProduct)
-    const basketUpdated = removeObjectById(idBasketProduct, basketCopy)
-
-    //3. update du state
+    const basketUpdated = removeObjectById(idBasketProduct, basket)
     setBasket(basketUpdated)
   }
 

--- a/src/hooks/useBasket.js
+++ b/src/hooks/useBasket.js
@@ -1,36 +1,33 @@
 import { useState } from "react"
-import { fakeBasket } from "../fakeData/fakeBasket"
 import { deepClone, findObjectById, findIndexById, removeObjectById } from "../utils/array"
+import { fakeBasket } from "../fakeData/fakeBasket"
 
 export const useBasket = () => {
   const [basket, setBasket] = useState(fakeBasket.EMPTY)
 
-  const handleAddToBasket = (productToAdd) => {
+  const handleAddToBasket = (idProductToAdd) => {
     const basketCopy = deepClone(basket)
-    const isProductAlreadyInBasket = findObjectById(productToAdd.id, basketCopy) !== undefined
+    const productAlreadyInBasket = findObjectById(idProductToAdd, basketCopy)
 
-    // 1er cas : le produit n'est pas déjà dans le basket
-    if (!isProductAlreadyInBasket) {
-      createNewProductInBasket(productToAdd, basketCopy, setBasket)
+    if (productAlreadyInBasket) {
+      incrementProductAlreadyInBasket(idProductToAdd, basketCopy)
       return
     }
-    // 2ème cas : le produit est déjà dans le basket
-    incrementProductAlreadyInBasket(productToAdd, basketCopy)
+
+    createNewBasketProduct(idProductToAdd, basketCopy, setBasket)
   }
 
-  const incrementProductAlreadyInBasket = (productToAdd, basketCopy) => {
-    const indexOfBasketProductToIncrement = findIndexById(productToAdd.id, basketCopy)
+  const incrementProductAlreadyInBasket = (idProductToAdd, basketCopy) => {
+    const indexOfBasketProductToIncrement = findIndexById(idProductToAdd, basketCopy)
     basketCopy[indexOfBasketProductToIncrement].quantity += 1
     setBasket(basketCopy)
   }
 
-  const createNewProductInBasket = (productToAdd, basketCopy, setBasket) => {
-    const newBasketProduct = {
-      ...productToAdd,
-      quantity: 1,
-    }
-    const basketUpdated = [newBasketProduct, ...basketCopy]
-    setBasket(basketUpdated)
+  const createNewBasketProduct = (idProductToAdd, basketCopy, setBasket) => {
+    // we do not re-create a whole product, we only add the extra info a basket product has in comparison to a menu product
+    const newBasketProduct = { id: idProductToAdd, quantity: 1 }
+    const newBasket = [newBasketProduct, ...basketCopy]
+    setBasket(newBasket)
   }
 
   const handleDeleteBasketProduct = (idBasketProduct) => {

--- a/src/hooks/useBasket.js
+++ b/src/hooks/useBasket.js
@@ -1,13 +1,13 @@
 import { useState } from "react"
 import { fakeBasket } from "../fakeData/fakeBasket"
-import { deepClone, filter, find, findIndex } from "../utils/array"
+import { deepClone, findObjectById, findIndexById, removeObjectById } from "../utils/array"
 
 export const useBasket = () => {
   const [basket, setBasket] = useState(fakeBasket.EMPTY)
 
   const handleAddToBasket = (productToAdd) => {
     const basketCopy = deepClone(basket)
-    const isProductAlreadyInBasket = find(productToAdd.id, basketCopy) !== undefined
+    const isProductAlreadyInBasket = findObjectById(productToAdd.id, basketCopy) !== undefined
 
     // 1er cas : le produit n'est pas déjà dans le basket
     if (!isProductAlreadyInBasket) {
@@ -19,7 +19,7 @@ export const useBasket = () => {
   }
 
   const incrementProductAlreadyInBasket = (productToAdd, basketCopy) => {
-    const indexOfBasketProductToIncrement = findIndex(productToAdd.id, basketCopy)
+    const indexOfBasketProductToIncrement = findIndexById(productToAdd.id, basketCopy)
     basketCopy[indexOfBasketProductToIncrement].quantity += 1
     setBasket(basketCopy)
   }
@@ -39,7 +39,7 @@ export const useBasket = () => {
 
     //2. manip de la copie state
     //const basketUpdated = basketCopy.filter((product) => product.id !== idBasketProduct)
-    const basketUpdated = filter(idBasketProduct, basketCopy)
+    const basketUpdated = removeObjectById(idBasketProduct, basketCopy)
 
     //3. update du state
     setBasket(basketUpdated)

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -1,15 +1,19 @@
 export const deepClone = (array) => {
     return JSON.parse(JSON.stringify(array))
 }
-
-export const find = (id, array) => {
+  
+export const findObjectById = (id, array) => {
     return array.find((itemInArray) => itemInArray.id === id)
 }
-
-export const findIndex = (idWithUnknowwIndex, array) => {
+  
+export const findIndexById = (idWithUnknowwIndex, array) => {
     return array.findIndex((itemInArray) => itemInArray.id === idWithUnknowwIndex)
 }
-
-export const filter = (idOfItemToRemove, array) => {
+  
+  export const removeObjectById = (idOfItemToRemove, array) => {
     return array.filter((item) => item.id !== idOfItemToRemove)
+}
+  
+export const isEmpty = (array) => {
+    return array.length === 0
 }

--- a/src/utils/maths.js
+++ b/src/utils/maths.js
@@ -1,29 +1,18 @@
-import { findObjectById } from "./array"
-
 export function formatPrice(priceToFormat) {
-    let price = priceToFormat
-  
-    // @TODO: perhaps change this to if(!price) return 0
-    if (!price) return "0,00 €"
-    price = replaceFrenchCommaWithDot(price)
-  
-    const formattedPrice = new Intl.NumberFormat("fr-FR", {
-      style: "currency",
-      currency: "EUR",
-    }).format(price)
-    return formattedPrice
-  }
-  
-  export function replaceFrenchCommaWithDot(price) {
-    if (typeof price === "string") price = parseFloat(price.replace(",", "."))
-    return price
-  }
+  let price = priceToFormat
 
-  export const calculateSumToPay = (basket, menu) => {
-    return basket.reduce((total, basketProduct) => {
-      const menuProduct = findObjectById(basketProduct.id, menu)
-      total += menuProduct.price * basketProduct.quantity
-      return total
-    }, 0)
-  }
-  
+  // @TODO: perhaps change this to if(!price) return 0
+  if (!price) return "0,00 €"
+  price = replaceFrenchCommaWithDot(price)
+
+  const formattedPrice = new Intl.NumberFormat("fr-FR", {
+    style: "currency",
+    currency: "EUR",
+  }).format(price)
+  return formattedPrice
+}
+
+export function replaceFrenchCommaWithDot(price) {
+  if (typeof price === "string") price = parseFloat(price.replace(",", "."))
+  return price
+}

--- a/src/utils/maths.js
+++ b/src/utils/maths.js
@@ -1,3 +1,5 @@
+import { findObjectById } from "./array"
+
 export function formatPrice(priceToFormat) {
     let price = priceToFormat
   
@@ -15,5 +17,13 @@ export function formatPrice(priceToFormat) {
   export function replaceFrenchCommaWithDot(price) {
     if (typeof price === "string") price = parseFloat(price.replace(",", "."))
     return price
+  }
+
+  export const calculateSumToPay = (basket, menu) => {
+    return basket.reduce((total, basketProduct) => {
+      const menuProduct = findObjectById(basketProduct.id, menu)
+      total += menuProduct.price * basketProduct.quantity
+      return total
+    }, 0)
   }
   


### PR DESCRIPTION
✅ Règles métier de modification

Quand j'entre en mode Admin, les cartes du panier deviennent "clickables" et au click d'une carte, le panel admin s'ouvre sur l'onglet "modifier un produit" avec les mêmes règles métier que dans le F09 (*).

Toute modification d'un produit à partir du formulaire entraîne une actualisation en temps réel des informations dans le menu ET dans le panier (si le produit est présent dans le panier).

Si l'utilisateur modifie le prix d'un produit présent dans le panier, le total de la commande s'actualise en conséquence et en temps réel.

Si le prix d'un produit est invalide, le prix affiché dans la carte du menu et du panier est "NaN €" et le montant à payer pour ce produit est retiré du montant total de la commande à payer.

(*) Rappel des règles métier du ticket F09 (*) :

Quand je clique sur une carte "survolable" du menu :

la carte est mise en évidence dans le menu de couleur orange (cf. maquette Figma)

le panel admin s’ouvre sur l'onglet "modifier un produit"

la place du message indice, un formulaire renseigné à partir des informations du produit sélectionné apparait (nom, lien URL / pré-visualisation et prix) comme pour le formulaire d'ajout de produit.

le focus est immédiatement mis sur le champ "nom produit" en fin de nom du produit.

Si je clique sur un produit "vide" du menu (i.e. sans nom, sans image renseigné et sans prix), le formulaire de modification est vide.

À partir de l’onglet "modifier un produit" du panel admin, si je modifie des informations du produit à partir du formulaire, je vois ses informations changer en temps réel dans le menu.

Si en cours de modification, je quitte le mode admin, quand je retourne sur le mode admin, je dois pouvoir reprendre mes modifications au même état où j'étais avant d'avoir quitté le mode admin.